### PR TITLE
Change pattern matching based on github's personal access token

### DIFF
--- a/cloudformation/era5-fargate.yaml
+++ b/cloudformation/era5-fargate.yaml
@@ -3,7 +3,7 @@ Parameters:
     Type: String
     Description: GitHub OAuth Token for accessing the Dask worker repository
     MinLength: 40
-    AllowedPattern: "[a-zA-Z0-9]+"
+    AllowedPattern: "ghp_[a-zA-Z0-9]+"
     NoEcho: true
 
   SagemakerCodeRepo:


### PR DESCRIPTION
Ran into some issues trying to deploy the cloud formation stack because of github's new token strategy. I changed the pattern matching but it is specifically for the ghp_ pattern used for personal access tokens. We could see if other types of tokens should be also accepted.

Fixes #6 